### PR TITLE
Updated README.md and keepy.sql

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Run npm install to get all the needed Nodejs modules.
 npm install 
 ```
 
-Edit the .env.example file and set your Streams Gateway URL, port and endpoint. 
+Edit the .env.example file and set your [Streams Gateway URL](https://github.com/iot2tangle/Streams-http-gateway), port and endpoint. 
 ```
 # Rename this file to .env
 GATEWAY_URL=http://YOUR_GW_IP:8080/sensor_data

--- a/keepy.sql
+++ b/keepy.sql
@@ -11,5 +11,5 @@ CREATE TABLE `messages` (
 
 CREATE USER 'keepy'@'localhost' IDENTIFIED BY 'your_password';
 GRANT ALL PRIVILEGES ON * . * TO 'keepy'@'localhost';
-ALTER USER 'keepy'@localhost IDENTIFIED WITH mysql_native_password BY 'your_password';
+ALTER USER 'keepy'@localhost IDENTIFIED BY 'your_password';
 FLUSH PRIVILEGES;


### PR DESCRIPTION
I added a link in the readme to the gateway github. I had to seach for it, but the link in there allows quick access.

The other thing I did was remove `WITH mysql_native_password` from,

     ALTER USER 'keepy'@localhost IDENTIFIED WITH mysql_native_password BY 'your_password';

Because it was failing on my system. By default mariadb and mysql use `mysql_native_password` so this is redundant. I use `mariadb` and this command was failing with it.